### PR TITLE
ugpraded project to gradle 8.12

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.7.2" apply false
+    id("com.android.application") version "8.12.0" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.google.dagger.hilt.android") version "2.52" apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.2"
+agp = "8.12.0"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.25"
 coreKtx = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Aug 02 22:19:54 CDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
 Why Upgrade? AGP 8.12 & Gradle 8.13 Benefits

  Android Gradle Plugin 8.7.2 → 8.12:
  - API Level 36 support - Latest Android features
  - Better test manifest handling - Custom AndroidManifest.xml for unit tests
  - Improved error reporting - Clearer build failure messages
  - Performance fixes - Better artifact transform handling

  Gradle Wrapper 8.9 → 8.13:
  - Auto JVM provisioning - Automatically downloads matching Java toolchain
  - Better IDE integration - Enhanced Problems API for IDEs like Android Studio
  - Improved test reporting - More accurate test execution timing
  - Enhanced dependency resolution - Better error messages for variant issues

  General Benefits:
  - Security patches - Bug fixes and security improvements
  - Build performance - Incremental optimizations across versions
  - Tool compatibility - Better integration with latest Android Studio features
  - Future-proofing - Staying current prevents larger upgrade efforts later